### PR TITLE
Remove safePermit for permit

### DIFF
--- a/contracts/lib/TokenUtils.sol
+++ b/contracts/lib/TokenUtils.sol
@@ -30,7 +30,7 @@ library TokenUtils {
         bytes32 _r,
         bytes32 _s
     ) internal onlyERC20(_token) {
-        IERC20Permit(_token).safePermit(
+        IERC20Permit(_token).permit(
             _owner,
             _spender,
             _value,


### PR DESCRIPTION
The function changed was removed in favor of simply using `permit`. Though these contracts use an older version of the ERC20Permit interface, newer implementations (ours) do not compile due to this issue
